### PR TITLE
fix: fix broken linkedin link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,7 @@ extra:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/oscakampala
     - icon: fontawesome/brands/linkedin
-      link: https://linkedin.com/in/oscakampala
+      link: https://www.linkedin.com/company/open-source-community-africa-kampala/
     - icon: fontawesome/brands/instagram
       link: https://www.instagram.com/oscakampala
 


### PR DESCRIPTION
Currently results in a 404 
![Screenshot from 2023-02-21 06-13-17](https://user-images.githubusercontent.com/65954740/220238388-4490bb51-ab60-4a18-9331-6d89a24d5f77.png)
