### PR TITLE
docs: Feedback and Support section 

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,6 +71,7 @@ Your pull request will be reviewed by the project maintainers, who may ask you t
 If you have any questions, comments, or feedback about the Autotelegram project, please send them in by;
 
 - [Opening an issue on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/issues/new)
+- [Starting a Discussion on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/discussions/new/choose)
 We also welcome feature requests and bug reports.
 
 If you need help using the tool or contributing to the project, you can;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,6 +72,7 @@ If you have any questions, comments, or feedback about the Autotelegram project,
 
 - [Opening an Issue on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/issues/new)
 - [Starting a Discussion on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/discussions/new/choose)
+
 We also welcome feature requests and bug reports.
 
 If you need help using the tool or contributing to the project, you can;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,10 +70,10 @@ Your pull request will be reviewed by the project maintainers, who may ask you t
 
 If you have any questions, comments, or feedback about the Autotelegram project, please open an issue on GitHub. We also welcome feature requests and bug reports.
 
-If you need help using the tool or contributing to the project, you can:
+If you need help using the tool or contributing to the project, you can;
 
 - <a href="https://t.me/oscakampala/1">Join our Telegram group</a> 
-- <a href="https://twitter.com/oscakampala" >Follow OSCA-Kla on twitter</a>
+- <a href="https://twitter.com/oscakampala" >Follow OSCA Kampala on Twitter</a>
 
 ## Maintainers
 The Autotelegram project is maintained by the following contributors:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,7 +70,7 @@ Your pull request will be reviewed by the project maintainers, who may ask you t
 
 If you have any questions, comments, or feedback about the Autotelegram project, please send them in by;
 
-- [Opening an issue on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/issues/new)
+- [Opening an Issue on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/issues/new)
 - [Starting a Discussion on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/discussions/new/choose)
 We also welcome feature requests and bug reports.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,10 @@ Your pull request will be reviewed by the project maintainers, who may ask you t
 
 ## Feedback and Support
 
-If you have any questions, comments, or feedback about the Autotelegram project, please open an issue on GitHub. We also welcome feature requests and bug reports.
+If you have any questions, comments, or feedback about the Autotelegram project, please send them in by;
+
+- [Opening an issue on GitHub](https://github.com/OSCA-Kampala-Chapter/autotelegram/issues/new)
+We also welcome feature requests and bug reports.
 
 If you need help using the tool or contributing to the project, you can;
 


### PR DESCRIPTION
- improve wording in feedback and support section
- change OSCA_KLA to OSCA Kampala to convey proper naming
- bullet feedback options for communication
- add link to creating a new issue
- add discussion option to means of communication
- enhance typography