### PR TITLE
chore: ignore venv (virtual env )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.egg
 *.egg-info
+venv


### PR DESCRIPTION
This pr seeks to make it easy for contributors that are having a dedicated virtual environment `venv` so as to ignore those files when submitting where pull requests